### PR TITLE
Fix zombie process due to voice connections not being teared down

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,18 +9,14 @@ import messenger from "@messenger/discord/discord-messenger";
       databaseUrl: mongoDbUrl
     });
   } catch (e) {
-    logger.error("Unable to start messenger");
+    logger.error("Unable to start bot");
   }
 })();
 
-process.on("SIGINT", async () => {
+const stopMessenger = async () => {
   await messenger.stop();
-});
+  logger.info("Bot stopped!");
+};
+const registerStop = (signal: string) => process.on(signal, stopMessenger);
 
-process.on("SIGTERM", async () => {
-  await messenger.stop();
-});
-
-process.on("SIGQUIT", async () => {
-  await messenger.stop();
-});
+["SIGINT", "SIGTERM", "SIGQUIT"].forEach(registerStop);

--- a/src/handlers/base/event-handler.ts
+++ b/src/handlers/base/event-handler.ts
@@ -5,7 +5,6 @@ import Client from "@model/base/client";
 import Member from "@model/base/member";
 import Message from "@model/base/message";
 import CommandExecutionDataImpl from "@store/commands/command-execution-data-impl";
-import { CustomCommandType } from "@store/models/custom-command";
 import Store from "@store/store";
 import path from "path";
 

--- a/src/messenger/discord/discord-messenger.ts
+++ b/src/messenger/discord/discord-messenger.ts
@@ -18,9 +18,13 @@ class DiscordMessenger implements Messenger {
   }
 
   public async stop(): Promise<void> {
-    const clientPromise = this.client.destroy();
-    const handlerPromise = this.eventHandler.destroy();
-    await Promise.all([clientPromise, handlerPromise]);
+    await this.eventHandler.destroy();
+    // Client needs to tear down any existing voice connections before shutdown
+    // otherwise the voice connections may become zombie processes after client destruction
+    this.client.voice?.connections?.forEach(connection => {
+      connection.disconnect();
+    });
+    await this.client.destroy();
   }
 }
 

--- a/src/store/mongo/database-store.ts
+++ b/src/store/mongo/database-store.ts
@@ -6,7 +6,6 @@ import * as DatabaseGuildModel from "@store/mongo/database-models/guild";
 import mongoose from "mongoose";
 
 export default class DatabaseStore implements Database {
-  private database = mongoose.connection;
   private guildCache = new Map<string, Guild>();
   private connectionsConfig: ClientVoiceConnectionsConfig | undefined;
 
@@ -18,7 +17,7 @@ export default class DatabaseStore implements Database {
   }
 
   public async close(): Promise<void> {
-    await this.database.close();
+    await mongoose.connection.close();
   }
 
   public async getAllGuilds(): Promise<Guild[]> {


### PR DESCRIPTION
If the bot was closed while a voice connection was active (bot still in a voice channel), then calling `Client#destroy` would destroy the client without cleaning up the voice connections. This means that processes related to the voice connection could still exist and would become zombie processes. This fix tears down those connections so that cleanup is properly done.